### PR TITLE
fix: cart item plus button shows wrong alert

### DIFF
--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -64,5 +64,6 @@ module.exports = {
     'react/jsx-props-no-spreading': 0,
     'no-extra-boolean-cast': 0,
     'react-hooks/exhaustive-deps': 0,
+    'radix': 0
   },
 };

--- a/client/src/pages/Cart.js
+++ b/client/src/pages/Cart.js
@@ -35,7 +35,7 @@ function Cart() {
                                                     dispatch(
                                                         addToCart(
                                                             item,
-                                                            item.quantity + 1,
+                                                            parseInt(item.quantity) + 1,
                                                             item.variant
                                                         )
                                                     )

--- a/client/src/redux/ActionCreators.js
+++ b/client/src/redux/ActionCreators.js
@@ -37,10 +37,9 @@ export const addToCart = (pizza, quantity, variant) => (dispatch, getState) => {
         price: pizza.prices[0][variant] * quantity,
     };
 
-    if (quantity > 10) {
+    if (parseInt(quantity) > 10) {
         alert("You can't add more than 10 Pizzas of the same type!");
-    } else if (quantity <= 0) {
-        // alert("You can't decrease quantity less than 1!");
+    } else if (parseInt(quantity) <= 0) {
         dispatch({
             type: ActionTypes.REMOVE_FROM_CART,
             payload: cartItem,


### PR DESCRIPTION
### Description
- fix: cart item plus button shows the wrong alert while increasing quantity.

#### Screenshot
- Now shows an alert when a user tries to add more than 10 quantities.

![image](https://user-images.githubusercontent.com/30983626/161383750-975a450c-867b-4ab8-8c2f-66f67e893ed1.png)
